### PR TITLE
ev3dev: replace opaque attribute accessor errors

### DIFF
--- a/dc_motor.go
+++ b/dc_motor.go
@@ -98,7 +98,7 @@ func (m *DCMotor) Command(comm string) *DCMotor {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: command %q not available for %s (available:%q)", comm, m, avail)
+		m.err = newInvalidValueError(m, command, "", comm, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, command, comm)
@@ -121,7 +121,7 @@ func (m *DCMotor) SetDutyCycleSetpoint(sp int) *DCMotor {
 		return m
 	}
 	if sp < -100 || 100 < sp {
-		m.err = fmt.Errorf("ev3dev: invalid duty cycle setpoint: %d (valid -100 - 100)", sp)
+		m.err = newValueOutOfRangeError(m, dutyCycleSetpoint, sp, -100, 100)
 		return m
 	}
 	m.err = setAttributeOf(m, dutyCycleSetpoint, fmt.Sprint(sp))
@@ -140,7 +140,7 @@ func (m *DCMotor) SetPolarity(p Polarity) *DCMotor {
 		return m
 	}
 	if p != Normal && p != Inversed {
-		m.err = fmt.Errorf("ev3dev: invalid polarity: %q (valid \"normal\" or \"inversed\")", p)
+		m.err = newInvalidValueError(m, polarity, "", string(p), []string{string(Normal), string(Inversed)})
 		return m
 	}
 	m.err = setAttributeOf(m, polarity, string(p))
@@ -158,7 +158,7 @@ func (m *DCMotor) SetRampUpSetpoint(sp time.Duration) *DCMotor {
 		return m
 	}
 	if sp < 0 || 10*time.Second < sp {
-		m.err = fmt.Errorf("ev3dev: invalid ramp up setpoint: %v (must be within 0-10s)", sp)
+		m.err = newDurationOutOfRangeError(m, rampUpSetpoint, sp, 0, 10*time.Second)
 		return m
 	}
 	m.err = setAttributeOf(m, rampUpSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -176,7 +176,7 @@ func (m *DCMotor) SetRampDownSetpoint(sp time.Duration) *DCMotor {
 		return m
 	}
 	if sp < 0 || 10*time.Second < sp {
-		m.err = fmt.Errorf("ev3dev: invalid ramp down setpoint: %v (must be within 0-10s)", sp)
+		m.err = newDurationOutOfRangeError(m, rampDownSetpoint, sp, 0, 10*time.Second)
 		return m
 	}
 	m.err = setAttributeOf(m, rampDownSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -216,7 +216,7 @@ func (m *DCMotor) SetStopAction(action string) *DCMotor {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: stop action %q not available for %s (available:%q)", action, m, avail)
+		m.err = newInvalidValueError(m, stopAction, "", action, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, stopAction, action)
@@ -239,7 +239,7 @@ func (m *DCMotor) SetTimeSetpoint(sp time.Duration) *DCMotor {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid time setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, timeSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, timeSetpoint, fmt.Sprint(int(sp/time.Millisecond)))

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,270 @@
+// Copyright ©2016 The ev3go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ev3dev
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// ValidValuer is an error caused by an invalid discrete value.
+type ValidValuer interface {
+	// Values returns the invalid value
+	// and a slice of valid values.
+	Values() (value string, valid []string)
+}
+
+// ValidRanger is an error caused by an invalid ranged integer value.
+type ValidRanger interface {
+	// Range returns the invalid value
+	// and the range of valid values.
+	Range() (value, min, max int)
+}
+
+// ValidDurationRanger is an error caused by an invalid ranged time.Duration value.
+type ValidDurationRanger interface {
+	// DurationRange returns the invalid value
+	// and the range of valid values.
+	DurationRange() (value, min, max time.Duration)
+}
+
+type invalidValueError struct {
+	dev   Device
+	attr  string
+	mesg  string
+	value string
+	valid []string
+
+	stack
+}
+
+func newInvalidValueError(dev Device, attr, message, value string, valid []string) invalidValueError {
+	if dev == nil {
+		panic("ev3dev: nil device")
+	}
+	for _, v := range valid {
+		if v == value {
+			panic(fmt.Sprintf("ev3dev: bad invalid value for %s %s: %q in %q",
+				dev, attr, value, valid))
+		}
+	}
+	return invalidValueError{
+		dev:   dev,
+		attr:  attr,
+		mesg:  message,
+		value: value,
+		valid: valid,
+		stack: callers(),
+	}
+}
+
+func (e invalidValueError) Error() string {
+	if e.mesg != "" {
+		return fmt.Sprintf("ev3dev: %s for %s %s: %q (valid:%q) at %s",
+			e.mesg, e.dev, e.attr, e.value, e.valid, e.caller(0))
+	}
+	return fmt.Sprintf("ev3dev: invalid value for %s %s: %q (valid:%q) at %s",
+		e.dev, e.attr, e.value, e.valid, e.caller(0))
+}
+
+func (e invalidValueError) Values() (value string, valid []string) {
+	return e.value, e.valid
+}
+
+type valueOutOfRangeError struct {
+	dev      Device
+	attr     string
+	value    int
+	min, max int
+
+	stack
+}
+
+func newValueOutOfRangeError(dev Device, attr string, v, min, max int) valueOutOfRangeError {
+	if dev == nil {
+		panic("ev3dev: nil device")
+	}
+	if min <= v && v <= max {
+		panic(fmt.Sprintf("ev3dev: bad value out of range error for %s %s: %v in %v-%v",
+			dev, attr, v, min, max))
+	}
+	return valueOutOfRangeError{
+		dev:   dev,
+		attr:  attr,
+		value: v,
+		min:   min,
+		max:   max,
+		stack: callers(),
+	}
+}
+
+func (e valueOutOfRangeError) Error() string {
+	return fmt.Sprintf("ev3dev: invalid value for %s %s: %d (must be in %d-%d) at %s",
+		e.dev, e.attr, e.value, e.min, e.max, e.caller(0))
+}
+
+func (e valueOutOfRangeError) Range() (value, min, max int) {
+	return e.value, e.min, e.max
+}
+
+type negativeDurationError struct {
+	dev      Device
+	attr     string
+	duration time.Duration
+
+	stack
+}
+
+func newNegativeDurationError(dev Device, attr string, d time.Duration) negativeDurationError {
+	if dev == nil {
+		panic("ev3dev: nil device")
+	}
+	if d >= 0 {
+		panic(fmt.Sprintf("ev3dev: bad negative duration for %s %s: %v not negative",
+			dev, attr, d))
+	}
+	return negativeDurationError{
+		dev:      dev,
+		attr:     attr,
+		duration: d,
+		stack:    callers(),
+	}
+}
+
+func (e negativeDurationError) Error() string {
+	return fmt.Sprintf("ev3dev: invalid duration for %s %s: %v (must be positive) at %s",
+		e.dev, e.attr, e.duration, e.caller(0))
+}
+
+func (e negativeDurationError) DurationRange() (value, min, max time.Duration) {
+	return e.duration, 0, math.MaxInt64
+}
+
+type durationOutOfRangeError struct {
+	dev      Device
+	attr     string
+	duration time.Duration
+	min, max time.Duration
+
+	stack
+}
+
+func newDurationOutOfRangeError(dev Device, attr string, d, min, max time.Duration) durationOutOfRangeError {
+	if dev == nil {
+		panic("ev3dev: nil device")
+	}
+	if min <= d && d <= max {
+		panic(fmt.Sprintf("ev3dev: bad duration out of range error for %s %s: %v in %v-%v",
+			dev, attr, d, min, max))
+	}
+	return durationOutOfRangeError{
+		dev:      dev,
+		attr:     attr,
+		duration: d,
+		min:      min,
+		max:      max,
+		stack:    callers(),
+	}
+}
+
+func (e durationOutOfRangeError) Error() string {
+	return fmt.Sprintf("ev3dev: invalid duration for %s %s: %v (must be in %v-%v) at %s",
+		e.dev, e.attr, e.duration, e.min, e.max, e.caller(0))
+}
+
+func (e durationOutOfRangeError) DurationRange() (value, min, max time.Duration) {
+	return e.duration, e.min, e.max
+}
+
+type attrOpError struct {
+	dev  Device
+	attr string
+	data string
+	op   string
+	err  error
+
+	stack
+}
+
+func newAttrOpError(dev Device, attr, data, op string, err error) attrOpError {
+	return attrOpError{
+		dev:   dev,
+		attr:  attr,
+		data:  data,
+		op:    op,
+		err:   err,
+		stack: callers(),
+	}
+}
+
+func (e attrOpError) Error() string {
+	return fmt.Sprintf("ev3dev: failed to %s %s %s attribute %s: %v at %s",
+		e.op, e.dev, e.attr, filepath.Join(e.dev.Path(), e.dev.String(), e.attr), e.err, e.caller(0))
+}
+
+func (e attrOpError) Cause() error { return e.err }
+
+type parseError struct {
+	dev  Device
+	attr string
+	err  error
+
+	stack
+}
+
+func newParseError(dev Device, attr string, err error) parseError {
+	return parseError{
+		dev:   dev,
+		attr:  attr,
+		err:   err,
+		stack: callers(),
+	}
+}
+
+func (e parseError) Error() string {
+	return fmt.Sprintf("ev3dev: failed to parse %s %s attribute %s: %v at %s",
+		e.dev, e.attr, filepath.Join(e.dev.Path(), e.dev.String(), e.attr), e.err, e.caller(1))
+}
+
+func (e parseError) Cause() error { return e.err }
+
+type syntaxError string
+
+func (e syntaxError) Error() string { return fmt.Sprintf("unexpected line: %q", string(e)) }
+
+type stack []uintptr
+
+func callers() stack {
+	var pc [64]uintptr
+	n := runtime.Callers(3, pc[:])
+	return pc[:n]
+}
+
+func (s stack) caller(depth int) string {
+	if len(s) <= depth || s[depth] == 0 {
+		return "<unknown caller>"
+	}
+	fn := runtime.FuncForPC(s[depth])
+	file, line := fn.FileLine(s[depth])
+	return fmt.Sprintf("%s:%d %s", filepath.Base(file), line, fn.Name())
+}
+
+func (s stack) writeTo(w io.Writer) (int, error) {
+	var n int
+	for _, pc := range s {
+		fn := runtime.FuncForPC(pc)
+		file, line := fn.FileLine(pc)
+		_n, err := fmt.Fprintf(w, "%s\n\t%s:%d\n", fn.Name(), filepath.Base(file), line)
+		n += _n
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,156 @@
+// Copyright ©2016 The ev3go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ev3dev
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var errorTests = []struct {
+	fn     func() error
+	panics bool
+
+	wantErrorPrefix string
+}{
+	{
+		fn: func() error {
+			return newInvalidValueError(nil, "", "", "", nil)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newInvalidValueError(mockDevice{}, "", "", "valid", []string{"ok", "valid"})
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newInvalidValueError(mockDevice{}, "attr", "", "invalid", []string{"ok", "valid"})
+		},
+		wantErrorPrefix: `ev3dev: invalid value for mock attr: "invalid" (valid:["ok" "valid"]) at errors_test.go:`,
+	},
+	{
+		fn: func() error {
+			return newInvalidValueError(mockDevice{}, "attr", "unexpected value", "surprise", []string{"ok", "valid"})
+		},
+		wantErrorPrefix: `ev3dev: unexpected value for mock attr: "surprise" (valid:["ok" "valid"]) at errors_test.go:`,
+	},
+
+	{
+		fn: func() error {
+			return newValueOutOfRangeError(nil, "", 0, -1, 1)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newValueOutOfRangeError(mockDevice{}, "", 0, 0, 0)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newValueOutOfRangeError(mockDevice{}, "attr", 0, 1, 2)
+		},
+		wantErrorPrefix: `ev3dev: invalid value for mock attr: 0 (must be in 1-2) at errors_test.go:`,
+	},
+
+	{
+		fn: func() error {
+			return newNegativeDurationError(nil, "", -1)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newNegativeDurationError(mockDevice{}, "", 0)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newNegativeDurationError(mockDevice{}, "attr", -1)
+		},
+		wantErrorPrefix: `ev3dev: invalid duration for mock attr: -1ns (must be positive) at errors_test.go:`,
+	},
+
+	{
+		fn: func() error {
+			return newDurationOutOfRangeError(nil, "", 0, -1, 1)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newDurationOutOfRangeError(mockDevice{}, "", 0, 0, 0)
+		},
+		panics: true,
+	},
+	{
+		fn: func() error {
+			return newDurationOutOfRangeError(mockDevice{}, "attr", 0, 1, 2)
+		},
+		wantErrorPrefix: `ev3dev: invalid duration for mock attr: 0s (must be in 1ns-2ns) at errors_test.go:`,
+	},
+}
+
+func panics(fn func() error) (err error, panicked bool) {
+	defer func() {
+		r := recover()
+		panicked = r != nil
+	}()
+	err = fn()
+	return err, panicked
+}
+
+func TestErrors(t *testing.T) {
+	for i, test := range errorTests {
+		got, panicked := panics(test.fn)
+		if panicked != test.panics {
+			t.Errorf("expected panic for test %d", i)
+			continue
+		}
+		if panicked {
+			continue
+		}
+		if errStr := fmt.Sprint(got); !strings.HasPrefix(errStr, test.wantErrorPrefix) {
+			t.Errorf("unexpected error string:\ngot:\n\t%s\nwant prefix:\n\t%s", errStr, test.wantErrorPrefix)
+		}
+	}
+}
+
+const (
+	wantCaller      = "stack_test.go:13 github.com/ev3go/ev3dev.testStack"
+	wantTracePrefix = `github.com/ev3go/ev3dev.testStack
+	stack_test.go:13
+github.com/ev3go/ev3dev.testStack
+	stack_test.go:13
+github.com/ev3go/ev3dev.testStack
+	stack_test.go:13
+github.com/ev3go/ev3dev.init
+	stack_test.go:7
+main.init
+`
+)
+
+func TestStack(t *testing.T) {
+	gotCaller := st.caller(0)
+	if gotCaller != wantCaller {
+		t.Errorf("unexpected caller string: got:%q want:%q", gotCaller, wantCaller)
+	}
+	var buf bytes.Buffer
+	_, err := st.writeTo(&buf)
+	if err != nil {
+		t.Errorf("unexpected error writing trace: %v", err)
+	}
+	gotTrace := buf.String()
+	if !strings.HasPrefix(gotTrace, wantTracePrefix) {
+		t.Errorf("unexpected trace string:\ngot:\n%s\nwant prefix:\n%s", gotTrace, wantTracePrefix)
+	}
+}

--- a/ev3dev.go
+++ b/ev3dev.go
@@ -182,6 +182,15 @@ var motorStateTable = map[string]MotorState{
 	stalled:    Stalled,
 }
 
+func keys(states map[string]MotorState) []string {
+	l := make([]string, 0, len(states))
+	for k := range states {
+		l = append(l, k)
+	}
+	sort.Strings(l)
+	return l
+}
+
 var motorStates = []string{
 	running,
 	ramping,
@@ -683,7 +692,7 @@ func stateFrom(d Device, data, _ string, err error) (MotorState, error) {
 	for _, s := range strings.Split(data, " ") {
 		bit, ok := motorStateTable[s]
 		if !ok {
-			return 0, newInvalidValueError(d, state, "unrecognized motor state", s, motorStates)
+			return 0, newInvalidValueError(d, state, "unrecognized motor state", s, keys(motorStateTable))
 		}
 		stat |= bit
 	}

--- a/ev3dev_conv_test.go
+++ b/ev3dev_conv_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -20,7 +21,7 @@ var intFromTest = []struct {
 	wantInt int
 	wantErr error
 }{
-	{data: "", attr: "empty", err: nil, wantInt: -1, wantErr: errors.New(`ev3dev: failed to parse empty: strconv.ParseInt: parsing "": invalid syntax`)},
+	{data: "", attr: "empty", err: nil, wantInt: -1, wantErr: errors.New(`ev3dev: failed to parse mock empty attribute path/mock/empty: strconv.ParseInt: parsing "": invalid syntax at ev3dev_conv_test.go:`)},
 	{data: "1", attr: "one", err: nil, wantInt: 1, wantErr: nil},
 	{data: "0", attr: "zero", err: nil, wantInt: 0, wantErr: nil},
 	{data: "-1", attr: "minus_one", err: nil, wantInt: -1, wantErr: nil},
@@ -29,10 +30,10 @@ var intFromTest = []struct {
 
 func TestIntFrom(t *testing.T) {
 	for _, test := range intFromTest {
-		gotInt, gotErr := intFrom(test.data, test.attr, test.err)
+		gotInt, gotErr := intFrom(mockDevice{}, test.data, test.attr, test.err)
 
-		if fmt.Sprint(gotErr) != fmt.Sprint(test.wantErr) {
-			t.Errorf("unexpected error: got:%v want:%v", gotErr, test.wantErr)
+		if !strings.HasPrefix(fmt.Sprint(gotErr), fmt.Sprint(test.wantErr)) {
+			t.Errorf("unexpected error:\ngot:\n\t%v\nwant prefix:\n\t%v", gotErr, test.wantErr)
 		}
 		if gotInt != test.wantInt {
 			t.Errorf("unexpected integer result: got:%d want:%d", gotInt, test.wantInt)
@@ -51,7 +52,7 @@ var float64FromTest = []struct {
 	wantFloat64 float64
 	wantErr     error
 }{
-	{data: "", attr: "empty", err: nil, wantFloat64: math.NaN(), wantErr: errors.New(`ev3dev: failed to parse empty: strconv.ParseFloat: parsing "": invalid syntax`)},
+	{data: "", attr: "empty", err: nil, wantFloat64: math.NaN(), wantErr: errors.New(`ev3dev: failed to parse mock empty attribute path/mock/empty: strconv.ParseFloat: parsing "": invalid syntax at ev3dev_conv_test.go:`)},
 	{data: "1", attr: "one", err: nil, wantFloat64: 1, wantErr: nil},
 	{data: "0", attr: "zero", err: nil, wantFloat64: 0, wantErr: nil},
 	{data: "-1", attr: "minus_one", err: nil, wantFloat64: -1, wantErr: nil},
@@ -60,10 +61,10 @@ var float64FromTest = []struct {
 
 func TestFloat64From(t *testing.T) {
 	for _, test := range float64FromTest {
-		gotFloat64, gotErr := float64From(test.data, test.attr, test.err)
+		gotFloat64, gotErr := float64From(mockDevice{}, test.data, test.attr, test.err)
 
-		if fmt.Sprint(gotErr) != fmt.Sprint(test.wantErr) {
-			t.Errorf("unexpected error: got:%v want:%v", gotErr, test.wantErr)
+		if !strings.HasPrefix(fmt.Sprint(gotErr), fmt.Sprint(test.wantErr)) {
+			t.Errorf("unexpected error:\ngot:\n\t%v\nwant prefix:\n\t%v", gotErr, test.wantErr)
 		}
 		if !isSame(gotFloat64, test.wantFloat64) {
 			t.Errorf("unexpected float64 result: got:%f want:%f", gotFloat64, test.wantFloat64)
@@ -78,7 +79,7 @@ var durationFromTest = []struct {
 	wantDuration time.Duration
 	wantErr      error
 }{
-	{data: "", attr: "empty", err: nil, wantDuration: -1, wantErr: errors.New(`ev3dev: failed to parse empty: strconv.ParseInt: parsing "": invalid syntax`)},
+	{data: "", attr: "empty", err: nil, wantDuration: -1, wantErr: errors.New(`ev3dev: failed to parse mock empty attribute path/mock/empty: strconv.ParseInt: parsing "": invalid syntax at ev3dev_conv_test.go:`)},
 	{data: "1", attr: "one", err: nil, wantDuration: 1 * time.Millisecond, wantErr: nil},
 	{data: "0", attr: "zero", err: nil, wantDuration: 0, wantErr: nil},
 	{data: "-1", attr: "minus_one", err: nil, wantDuration: -1 * time.Millisecond, wantErr: nil},
@@ -87,10 +88,10 @@ var durationFromTest = []struct {
 
 func TestDurationFrom(t *testing.T) {
 	for _, test := range durationFromTest {
-		gotDuration, gotErr := durationFrom(test.data, test.attr, test.err)
+		gotDuration, gotErr := durationFrom(mockDevice{}, test.data, test.attr, test.err)
 
-		if fmt.Sprint(gotErr) != fmt.Sprint(test.wantErr) {
-			t.Errorf("unexpected error: got:%v want:%v", gotErr, test.wantErr)
+		if !strings.HasPrefix(fmt.Sprint(gotErr), fmt.Sprint(test.wantErr)) {
+			t.Errorf("unexpected error:\ngot:\n\t%v\nwant prefix:\n\t%v", gotErr, test.wantErr)
 		}
 		if gotDuration != test.wantDuration {
 			t.Errorf("unexpected duration result: got:%v want:%v", gotDuration, test.wantDuration)
@@ -114,10 +115,10 @@ var stringSliceFromTest = []struct {
 
 func TestStringSliceFrom(t *testing.T) {
 	for _, test := range stringSliceFromTest {
-		gotStrings, gotErr := stringSliceFrom(test.data, test.attr, test.err)
+		gotStrings, gotErr := stringSliceFrom(mockDevice{}, test.data, test.attr, test.err)
 
 		if fmt.Sprint(gotErr) != fmt.Sprint(test.wantErr) {
-			t.Errorf("unexpected error: got:%v want:%v", gotErr, test.wantErr)
+			t.Errorf("unexpected error:\ngot:\n\t%v\nwant prefix:\n\t%v", gotErr, test.wantErr)
 		}
 		if !reflect.DeepEqual(gotStrings, test.wantStrings) {
 			t.Errorf("unexpected strings result: got:%v want:%v", gotStrings, test.wantStrings)
@@ -137,16 +138,16 @@ var ueventFromTest = []struct {
 	{data: "", attr: "empty", err: nil, wantUevents: nil, wantErr: nil},
 	{data: "one=1", attr: "one", err: nil, wantUevents: ue{"one": "1"}, wantErr: nil},
 	{data: "zero=0\none=1", attr: "two", err: nil, wantUevents: ue{"zero": "0", "one": "1"}, wantErr: nil},
-	{data: "0", attr: "zero", err: nil, wantUevents: nil, wantErr: errors.New(`ev3dev: failed to parse zero: unexpected line "0"`)},
+	{data: "0", attr: "zero", err: nil, wantUevents: nil, wantErr: errors.New(`ev3dev: failed to parse mock zero attribute path/mock/zero: unexpected line: "0" at ev3dev_conv_test.go:`)},
 	{data: "0", attr: "prior", err: errors.New("prior error"), wantUevents: nil, wantErr: errors.New("prior error")},
 }
 
 func TestUeventFrom(t *testing.T) {
 	for _, test := range ueventFromTest {
-		gotUevents, gotErr := ueventFrom(test.data, test.attr, test.err)
+		gotUevents, gotErr := ueventFrom(mockDevice{}, test.data, test.attr, test.err)
 
-		if fmt.Sprint(gotErr) != fmt.Sprint(test.wantErr) {
-			t.Errorf("unexpected error: got:%v want:%v", gotErr, test.wantErr)
+		if !strings.HasPrefix(fmt.Sprint(gotErr), fmt.Sprint(test.wantErr)) {
+			t.Errorf("unexpected error:\ngot:\n\t%v\nwant prefix:\n\t%v", gotErr, test.wantErr)
 		}
 		if !reflect.DeepEqual(gotUevents, test.wantUevents) {
 			t.Errorf("unexpected uevent result: got:%v want:%v", gotUevents, test.wantUevents)

--- a/ev3dev_conv_test.go
+++ b/ev3dev_conv_test.go
@@ -126,6 +126,37 @@ func TestStringSliceFrom(t *testing.T) {
 	}
 }
 
+var stateFromTest = []struct {
+	data      string
+	attr      string
+	err       error
+	wantState MotorState
+	wantErr   error
+}{
+	{data: "", attr: "empty", err: nil, wantState: 0, wantErr: nil},
+	{data: running, attr: running, err: nil, wantState: Running, wantErr: nil},
+	{data: ramping, attr: ramping, err: nil, wantState: Ramping, wantErr: nil},
+	{data: holding, attr: holding, err: nil, wantState: Holding, wantErr: nil},
+	{data: overloaded, attr: overloaded, err: nil, wantState: Overloaded, wantErr: nil},
+	{data: stalled, attr: stalled, err: nil, wantState: Stalled, wantErr: nil},
+	{data: running + " " + stalled, attr: running + " " + stalled, err: nil, wantState: Running | Stalled, wantErr: nil},
+	{data: "invalid", attr: "invalid", err: nil, wantState: 0, wantErr: errors.New(`ev3dev: unrecognized motor state for mock state: "invalid" (valid:["running" "ramping" "holding" "overloaded" "stalled"]) at ev3dev.go:`)},
+	{data: "0", attr: "prior", err: errors.New("prior error"), wantState: 0, wantErr: errors.New("prior error")},
+}
+
+func TestStateFrom(t *testing.T) {
+	for _, test := range stateFromTest {
+		gotState, gotErr := stateFrom(mockDevice{}, test.data, test.attr, test.err)
+
+		if !strings.HasPrefix(fmt.Sprint(gotErr), fmt.Sprint(test.wantErr)) {
+			t.Errorf("unexpected error:\ngot:\n\t%v\nwant prefix:\n\t%v", gotErr, test.wantErr)
+		}
+		if gotState != test.wantState {
+			t.Errorf("unexpected state result: got:%v want:%v", gotState, test.wantState)
+		}
+	}
+}
+
 type ue map[string]string
 
 var ueventFromTest = []struct {

--- a/ev3dev_conv_test.go
+++ b/ev3dev_conv_test.go
@@ -140,7 +140,7 @@ var stateFromTest = []struct {
 	{data: overloaded, attr: overloaded, err: nil, wantState: Overloaded, wantErr: nil},
 	{data: stalled, attr: stalled, err: nil, wantState: Stalled, wantErr: nil},
 	{data: running + " " + stalled, attr: running + " " + stalled, err: nil, wantState: Running | Stalled, wantErr: nil},
-	{data: "invalid", attr: "invalid", err: nil, wantState: 0, wantErr: errors.New(`ev3dev: unrecognized motor state for mock state: "invalid" (valid:["running" "ramping" "holding" "overloaded" "stalled"]) at ev3dev.go:`)},
+	{data: "invalid", attr: "invalid", err: nil, wantState: 0, wantErr: errors.New(`ev3dev: unrecognized motor state for mock state: "invalid" (valid:["holding" "overloaded" "ramping" "running" "stalled"]) at ev3dev.go:`)},
 	{data: "0", attr: "prior", err: errors.New("prior error"), wantState: 0, wantErr: errors.New("prior error")},
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -11,6 +11,13 @@ func init() {
 	Prefix = prefix
 }
 
+type mockDevice struct{}
+
+func (d mockDevice) Path() string   { return "path" }
+func (d mockDevice) Type() string   { return "mock" }
+func (d mockDevice) Err() error     { return nil }
+func (d mockDevice) String() string { return "mock" }
+
 const (
 	AddressName                   = address
 	BinDataName                   = binData

--- a/linear_actuator.go
+++ b/linear_actuator.go
@@ -6,6 +6,7 @@ package ev3dev
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"time"
 )
@@ -98,7 +99,7 @@ func (m *LinearActuator) Command(comm string) *LinearActuator {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: command %q not available for %s (available:%q)", comm, m, avail)
+		m.err = newInvalidValueError(m, command, "", comm, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, command, comm)
@@ -133,7 +134,7 @@ func (m *LinearActuator) SetDutyCycleSetpoint(sp int) *LinearActuator {
 		return m
 	}
 	if sp < -100 || 100 < sp {
-		m.err = fmt.Errorf("ev3dev: invalid duty cycle setpoint: %d (valid -100 - 100)", sp)
+		m.err = newValueOutOfRangeError(m, dutyCycleSetpoint, sp, -100, 100)
 		return m
 	}
 	m.err = setAttributeOf(m, dutyCycleSetpoint, fmt.Sprint(sp))
@@ -152,7 +153,7 @@ func (m *LinearActuator) SetPolarity(p Polarity) *LinearActuator {
 		return m
 	}
 	if p != Normal && p != Inversed {
-		m.err = fmt.Errorf("ev3dev: invalid polarity: %q (valid \"normal\" or \"inversed\")", p)
+		m.err = newInvalidValueError(m, polarity, "", string(p), []string{string(Normal), string(Inversed)})
 		return m
 	}
 	m.err = setAttributeOf(m, polarity, string(p))
@@ -170,7 +171,7 @@ func (m *LinearActuator) SetPosition(pos int) *LinearActuator {
 		return m
 	}
 	if pos != int(int32(pos)) {
-		m.err = fmt.Errorf("ev3dev: invalid position: %d (valid in int32)", pos)
+		m.err = newValueOutOfRangeError(m, position, pos, math.MinInt32, math.MaxInt32)
 		return m
 	}
 	m.err = setAttributeOf(m, position, fmt.Sprint(pos))
@@ -235,7 +236,7 @@ func (m *LinearActuator) SetPositionSetpoint(sp int) *LinearActuator {
 		return m
 	}
 	if sp != int(int32(sp)) {
-		m.err = fmt.Errorf("ev3dev: invalid position setpoint: %d (valid in int32)", sp)
+		m.err = newValueOutOfRangeError(m, positionSetpoint, sp, math.MinInt32, math.MaxInt32)
 		return m
 	}
 	m.err = setAttributeOf(m, positionSetpoint, fmt.Sprint(sp))
@@ -272,7 +273,7 @@ func (m *LinearActuator) SetRampUpSetpoint(sp time.Duration) *LinearActuator {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid ramp up setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, rampUpSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, rampUpSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -290,7 +291,7 @@ func (m *LinearActuator) SetRampDownSetpoint(sp time.Duration) *LinearActuator {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid ramp down setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, rampDownSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, rampDownSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -372,7 +373,7 @@ func (m *LinearActuator) SetStopAction(action string) *LinearActuator {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: stop action %q not available for %s (available:%q)", action, m, avail)
+		m.err = newInvalidValueError(m, stopAction, "", action, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, stopAction, action)
@@ -395,7 +396,7 @@ func (m *LinearActuator) SetTimeSetpoint(sp time.Duration) *LinearActuator {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid time setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, timeSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, timeSetpoint, fmt.Sprint(int(sp/time.Millisecond)))

--- a/servo_motor.go
+++ b/servo_motor.go
@@ -97,7 +97,7 @@ func (m *ServoMotor) Command(comm string) *ServoMotor {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: command %q not available for %s (available:%q)", comm, m, avail)
+		m.err = newInvalidValueError(m, command, "", comm, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, command, comm)
@@ -115,7 +115,7 @@ func (m *ServoMotor) SetMaxPulseSetpoint(sp time.Duration) *ServoMotor {
 		return m
 	}
 	if sp < 2300*time.Millisecond || 2700*time.Millisecond < sp {
-		m.err = fmt.Errorf("ev3dev: invalid max pulse setpoint: %d (valid 2300ms-1700ms)", sp)
+		m.err = newDurationOutOfRangeError(m, maxPulseSetpoint, sp, 2300*time.Millisecond, 2700*time.Millisecond)
 		return m
 	}
 	m.err = setAttributeOf(m, maxPulseSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -133,7 +133,7 @@ func (m *ServoMotor) SetMidPulseSetpoint(sp time.Duration) *ServoMotor {
 		return m
 	}
 	if sp < 1300*time.Millisecond || 1700*time.Millisecond < sp {
-		m.err = fmt.Errorf("ev3dev: invalid mid pulse setpoint: %d (valid 1300ms-1700ms)", sp)
+		m.err = newDurationOutOfRangeError(m, midPulseSetpoint, sp, 1300*time.Millisecond, 1700*time.Millisecond)
 		return m
 	}
 	m.err = setAttributeOf(m, midPulseSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -151,7 +151,7 @@ func (m *ServoMotor) SetMinPulseSetpoint(sp time.Duration) *ServoMotor {
 		return m
 	}
 	if sp < 300*time.Millisecond || 700*time.Millisecond < sp {
-		m.err = fmt.Errorf("ev3dev: invalid min pulse setpoint: %d (valid 300ms-700ms)", sp)
+		m.err = newDurationOutOfRangeError(m, minPulseSetpoint, sp, 300*time.Millisecond, 700*time.Millisecond)
 		return m
 	}
 	m.err = setAttributeOf(m, minPulseSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -170,7 +170,7 @@ func (m *ServoMotor) SetPolarity(p Polarity) *ServoMotor {
 		return m
 	}
 	if p != Normal && p != Inversed {
-		m.err = fmt.Errorf("ev3dev: invalid polarity: %q (valid \"normal\" or \"inversed\")", p)
+		m.err = newInvalidValueError(m, polarity, "", string(p), []string{string(Normal), string(Inversed)})
 		return m
 	}
 	m.err = setAttributeOf(m, polarity, string(p))
@@ -189,7 +189,7 @@ func (m *ServoMotor) SetPositionSetpoint(sp int) *ServoMotor {
 		return m
 	}
 	if sp < -100 || 100 < sp {
-		m.err = fmt.Errorf("ev3dev: invalid position: %d (valid in -100 - 100)", sp)
+		m.err = newValueOutOfRangeError(m, positionSetpoint, sp, -100, 100)
 		return m
 	}
 	m.err = setAttributeOf(m, positionSetpoint, fmt.Sprint(sp))
@@ -207,7 +207,7 @@ func (m *ServoMotor) SetRateSetpoint(sp time.Duration) *ServoMotor {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid ramp up setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, rateSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, rateSetpoint, fmt.Sprint(int(sp/time.Millisecond)))

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,14 @@
+// Copyright ©2016 The ev3go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ev3dev
+
+var st = testStack(3)
+
+func testStack(n int) stack {
+	if n == 0 {
+		return callers()
+	}
+	return testStack(n - 1)
+}

--- a/tacho_motor.go
+++ b/tacho_motor.go
@@ -6,6 +6,7 @@ package ev3dev
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"time"
 )
@@ -98,7 +99,7 @@ func (m *TachoMotor) Command(comm string) *TachoMotor {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: command %q not available for %s (available:%q)", comm, m, avail)
+		m.err = newInvalidValueError(m, command, "", comm, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, command, comm)
@@ -127,7 +128,7 @@ func (m *TachoMotor) SetDutyCycleSetpoint(sp int) *TachoMotor {
 		return m
 	}
 	if sp < -100 || 100 < sp {
-		m.err = fmt.Errorf("ev3dev: invalid duty cycle setpoint: %d (valid -100 - 100)", sp)
+		m.err = newValueOutOfRangeError(m, dutyCycleSetpoint, sp, -100, 100)
 		return m
 	}
 	m.err = setAttributeOf(m, dutyCycleSetpoint, fmt.Sprint(sp))
@@ -146,7 +147,7 @@ func (m *TachoMotor) SetPolarity(p Polarity) *TachoMotor {
 		return m
 	}
 	if p != Normal && p != Inversed {
-		m.err = fmt.Errorf("ev3dev: invalid polarity: %q (valid \"normal\" or \"inversed\")", p)
+		m.err = newInvalidValueError(m, polarity, "", string(p), []string{string(Normal), string(Inversed)})
 		return m
 	}
 	m.err = setAttributeOf(m, polarity, string(p))
@@ -164,7 +165,7 @@ func (m *TachoMotor) SetPosition(pos int) *TachoMotor {
 		return m
 	}
 	if pos != int(int32(pos)) {
-		m.err = fmt.Errorf("ev3dev: invalid position: %d (valid in int32)", pos)
+		m.err = newValueOutOfRangeError(m, position, pos, math.MinInt32, math.MaxInt32)
 		return m
 	}
 	m.err = setAttributeOf(m, position, fmt.Sprint(pos))
@@ -229,7 +230,7 @@ func (m *TachoMotor) SetPositionSetpoint(sp int) *TachoMotor {
 		return m
 	}
 	if sp != int(int32(sp)) {
-		m.err = fmt.Errorf("ev3dev: invalid position setpoint: %d (valid in int32)", sp)
+		m.err = newValueOutOfRangeError(m, positionSetpoint, sp, math.MinInt32, math.MaxInt32)
 		return m
 	}
 	m.err = setAttributeOf(m, positionSetpoint, fmt.Sprint(sp))
@@ -266,7 +267,7 @@ func (m *TachoMotor) SetRampUpSetpoint(sp time.Duration) *TachoMotor {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid ramp up setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, rampUpSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, rampUpSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -284,7 +285,7 @@ func (m *TachoMotor) SetRampDownSetpoint(sp time.Duration) *TachoMotor {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid ramp down setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, rampDownSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, rampDownSetpoint, fmt.Sprint(int(sp/time.Millisecond)))
@@ -366,7 +367,7 @@ func (m *TachoMotor) SetStopAction(action string) *TachoMotor {
 		}
 	}
 	if !ok {
-		m.err = fmt.Errorf("ev3dev: stop action %q not available for %s (available:%q)", action, m, avail)
+		m.err = newInvalidValueError(m, stopAction, "", action, avail)
 		return m
 	}
 	m.err = setAttributeOf(m, stopAction, action)
@@ -389,7 +390,7 @@ func (m *TachoMotor) SetTimeSetpoint(sp time.Duration) *TachoMotor {
 		return m
 	}
 	if sp < 0 {
-		m.err = fmt.Errorf("ev3dev: invalid time setpoint: %v (must be positive)", sp)
+		m.err = newNegativeDurationError(m, timeSetpoint, sp)
 		return m
 	}
 	m.err = setAttributeOf(m, timeSetpoint, fmt.Sprint(int(sp/time.Millisecond)))


### PR DESCRIPTION
The design is not finalised, but this makes future changes easier. Methods and types will be exported as necessary.

Updates #24.

@vladimir-ch Please take a look.