### PR TITLE
ev3dev: add sound event support

### DIFF
--- a/buttons.go
+++ b/buttons.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"reflect"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -147,43 +146,6 @@ var buttons = [...]uint{
 	key_right,
 	key_up,
 	key_down,
-}
-
-// Constants from uapi/asm-generic/ioctl.h and uapi/linux/input.h.
-const (
-	_ioc_read = 2
-
-	_ioc_nrbits   = 8
-	_ioc_typebits = 8
-	_ioc_sizebits = 14
-	_ioc_dirbits  = 2
-
-	_ioc_nrmask   = 1<<_ioc_nrbits - 1
-	_ioc_typemask = 1<<_ioc_typebits - 1
-	_ioc_sizemask = 1<<_ioc_sizebits - 1
-	_ioc_dirmask  = 1<<_ioc_dirbits - 1
-
-	// Calculate shifts for _ioc fields.
-	_ioc_nrshift   = 0                              // bits  0- 7
-	_ioc_typeshift = _ioc_nrshift + _ioc_nrbits     // bits  8-15
-	_ioc_sizeshift = _ioc_typeshift + _ioc_typebits // bits 16-29
-	_ioc_dirshift  = _ioc_sizeshift + _ioc_sizebits // bits 30-31
-)
-
-func eviocgkey(buf []byte) uintptr {
-	return _ioc_read<<_ioc_dirshift | uintptr(len(buf))<<_ioc_sizeshift | 'E'<<_ioc_typeshift | 0x18<<_ioc_nrshift
-}
-
-func ioctl(fd, cmd, ptr uintptr) error {
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
-
-func isSet(bit uint, buf []byte) bool {
-	return buf[bit>>3]&(1<<(bit&7)) != 0
 }
 
 const (

--- a/evdev.go
+++ b/evdev.go
@@ -1,0 +1,48 @@
+// Copyright ©2016 The ev3go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ev3dev
+
+import "syscall"
+
+// Constants from uapi/asm-generic/ioctl.h and uapi/linux/input.h.
+const (
+	_ioc_read = 2
+
+	_ioc_nrbits   = 8
+	_ioc_typebits = 8
+	_ioc_sizebits = 14
+	_ioc_dirbits  = 2
+
+	_ioc_nrmask   = 1<<_ioc_nrbits - 1
+	_ioc_typemask = 1<<_ioc_typebits - 1
+	_ioc_sizemask = 1<<_ioc_sizebits - 1
+	_ioc_dirmask  = 1<<_ioc_dirbits - 1
+
+	// Calculate shifts for _ioc fields.
+	_ioc_nrshift   = 0                              // bits  0- 7
+	_ioc_typeshift = _ioc_nrshift + _ioc_nrbits     // bits  8-15
+	_ioc_sizeshift = _ioc_typeshift + _ioc_typebits // bits 16-29
+	_ioc_dirshift  = _ioc_sizeshift + _ioc_sizebits // bits 30-31
+)
+
+func eviocgbit(ev byte, bits uint16) uintptr {
+	return _ioc_read<<_ioc_dirshift | uintptr(bits)<<_ioc_sizeshift | 'E'<<_ioc_typeshift | (0x20+uintptr(ev))<<_ioc_nrshift
+}
+
+func eviocgkey(buf []byte) uintptr {
+	return _ioc_read<<_ioc_dirshift | uintptr(len(buf))<<_ioc_sizeshift | 'E'<<_ioc_typeshift | 0x18<<_ioc_nrshift
+}
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func isSet(bit uint, buf []byte) bool {
+	return buf[bit>>3]&(1<<(bit&7)) != 0
+}

--- a/examples/speaker/speaker.go
+++ b/examples/speaker/speaker.go
@@ -1,0 +1,40 @@
+// Copyright ©2017 The ev3go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// speaker demonstrates use of the ev3dev speaker.
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/ev3go/ev3dev"
+)
+
+// SoundPath is the path to the ev3 sound events.
+const SoundPath = "/dev/input/by-path/platform-snd-legoev3-event"
+
+var speaker = ev3dev.NewSpeaker(SoundPath)
+
+func main() {
+	must(speaker.Init())
+	defer speaker.Close()
+
+	// Play tone at 440Hz for 200ms...
+	must(speaker.Tone(440))
+	time.Sleep(200 * time.Millisecond)
+
+	// play tone at 220Hz for 200ms...
+	must(speaker.Tone(220))
+	time.Sleep(200 * time.Millisecond)
+
+	// then stop tone playback.
+	must(speaker.Tone(0))
+}
+
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/speaker.go
+++ b/speaker.go
@@ -1,0 +1,84 @@
+// Copyright ©2017 The ev3go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ev3dev
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"reflect"
+)
+
+const (
+	tone = 0x02
+
+	ev_snd = 0x12
+	ev_max = 0x1f
+
+	evBufLen = (ev_max + 7) / 8
+)
+
+// Speaker is an evdev sound device.
+type Speaker struct {
+	path string
+	f    *os.File
+	buf  [16]byte
+}
+
+// NewSpeaker returns a new Speaker based on the given evdev snd device path.
+func NewSpeaker(path string) *Speaker {
+	s := Speaker{path: path}
+	binary.LittleEndian.PutUint16(s.buf[8:10], ev_snd)
+	binary.LittleEndian.PutUint16(s.buf[10:12], tone)
+	return &s
+}
+
+func hasSound(path string) (bool, error) {
+	ev, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("ev3dev: failed to open sound event device: %v", err)
+	}
+	defer ev.Close()
+
+	var buf [evBufLen]byte
+	err = ioctl(ev.Fd(), eviocgbit(0, ev_max), reflect.ValueOf(buf[:]).Index(0).Addr().Pointer())
+	if err != nil {
+		return false, fmt.Errorf("ev3dev: failed to set ioctl command for sound event device: %v", err)
+	}
+	return isSet(ev_snd, buf[:]), nil
+}
+
+// Init prepares a Speaker for use.
+func (s *Speaker) Init() error {
+	ok, err := hasSound(s.path)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("ev3dev: sound events not available for %q", s.path)
+	}
+
+	s.f, err = os.OpenFile(s.path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("ev3dev: failed to open sound event device: %v", err)
+	}
+	return nil
+}
+
+// Tone plays a tone at the specified frequency from the ev3 speaker.
+// If freq is zero, playing is stopped.
+func (s *Speaker) Tone(freq uint32) error {
+	binary.LittleEndian.PutUint32(s.buf[12:16], freq)
+	_, err := s.f.Write(s.buf[:])
+	return err
+}
+
+// Close closes the Speaker. After return, the Speaker may not be used unless
+// Init is called again.
+func (s *Speaker) Close() error {
+	err := s.f.Close()
+	s.f = nil
+	return err
+}


### PR DESCRIPTION
@dlech Please take a look.

This is very pared down, for example only `SND_TONE` is supported, since only it seems to work on the ev3. I have not tested this on evb.