### PR TITLE
ev3dev: remove ENOTSUP errors for zero length slice attribute tests

### DIFF
--- a/dc_motor_test.go
+++ b/dc_motor_test.go
@@ -138,9 +138,6 @@ type dcMotorCommands dcMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *dcMotorCommands) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*dcMotor)(m).commands()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -167,9 +164,6 @@ func (m *dcMotorCommand) Truncate(_ int64) error { return nil }
 func (m *dcMotorCommand) WriteAt(b []byte, off int64) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m._commands) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	command := string(chomp(b))
 	for _, c := range m._commands {
 		if command == c {
@@ -197,9 +191,6 @@ type dcMotorStopActions dcMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *dcMotorStopActions) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*dcMotor)(m).stopActions()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -423,9 +414,6 @@ type dcMotorStopAction dcMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *dcMotorStopAction) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*dcMotor)(m).stopActions()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -436,9 +424,6 @@ func (m *dcMotorStopAction) Truncate(_ int64) error { return nil }
 func (m *dcMotorStopAction) WriteAt(b []byte, off int64) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m._stopActions) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	stopAction := string(chomp(b))
 	for _, c := range m._stopActions {
 		if stopAction == c {
@@ -733,12 +718,6 @@ func TestDCMotor(t *testing.T) {
 			}
 			commands, err := m.Commands()
 			want := c.dcMotor.commands()
-			if len(want) == 0 {
-				if err == nil {
-					t.Error("expected error getting commands from non-commandable dcMotor")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting commands: %v", err)
 			}
@@ -956,12 +935,6 @@ func TestDCMotor(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			stopActions, err := m.StopActions()
-			if len(c.dcMotor.stopActions()) == 0 {
-				if err == nil {
-					t.Error("expected error getting stop actions from non-stop action dcMotor")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting stop actions: %v", err)
 			}

--- a/linear_actuator_test.go
+++ b/linear_actuator_test.go
@@ -191,9 +191,6 @@ type linearActuatorCommands linearActuator
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *linearActuatorCommands) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*linearActuator)(m).commands()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -220,9 +217,6 @@ func (m *linearActuatorCommand) Truncate(_ int64) error { return nil }
 func (m *linearActuatorCommand) WriteAt(b []byte, off int64) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m._commands) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	command := string(chomp(b))
 	for _, c := range m._commands {
 		if command == c {
@@ -250,9 +244,6 @@ type linearActuatorStopActions linearActuator
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *linearActuatorStopActions) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*linearActuator)(m).stopActions()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -854,9 +845,6 @@ type linearActuatorStopAction linearActuator
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *linearActuatorStopAction) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*linearActuator)(m).stopActions()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -867,9 +855,6 @@ func (m *linearActuatorStopAction) Truncate(_ int64) error { return nil }
 func (m *linearActuatorStopAction) WriteAt(b []byte, off int64) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m._stopActions) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	stopAction := string(chomp(b))
 	for _, c := range m._stopActions {
 		if stopAction == c {
@@ -1184,12 +1169,6 @@ func TestLinearActuator(t *testing.T) {
 			}
 			commands, err := m.Commands()
 			want := c.linearActuator.commands()
-			if len(want) == 0 {
-				if err == nil {
-					t.Error("expected error getting commands from non-commandable linearActuator")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting commands: %v", err)
 			}
@@ -1702,12 +1681,6 @@ func TestLinearActuator(t *testing.T) {
 			}
 			stopActions, err := m.StopActions()
 			want := c.linearActuator.stopActions()
-			if len(want) == 0 {
-				if err == nil {
-					t.Error("expected error getting stop actions from non-stop action linearActuator")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting stop actions: %v", err)
 			}

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -150,9 +150,6 @@ type sensorCommands sensor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (s *sensorCommands) ReadAt(b []byte, offset int64) (int, error) {
-	if len(s._commands) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, s)
 }
 
@@ -179,9 +176,6 @@ func (s *sensorCommand) Truncate(_ int64) error { return nil }
 func (s *sensorCommand) WriteAt(b []byte, off int64) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(s._commands) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	command := string(chomp(b))
 	for _, c := range s._commands {
 		if command == c {
@@ -821,12 +815,6 @@ func TestSensor(t *testing.T) {
 			}
 			commands, err := s.Commands()
 			want := c.sensor.commands()
-			if len(want) == 0 {
-				if err == nil {
-					t.Error("expected error getting commands from non-commandable sensor")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting commands: %v", err)
 			}

--- a/tacho_motor_test.go
+++ b/tacho_motor_test.go
@@ -191,9 +191,6 @@ type tachoMotorCommands tachoMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *tachoMotorCommands) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*tachoMotor)(m).commands()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -220,9 +217,6 @@ func (m *tachoMotorCommand) Truncate(_ int64) error { return nil }
 func (m *tachoMotorCommand) WriteAt(b []byte, off int64) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m._commands) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	command := string(chomp(b))
 	for _, c := range m._commands {
 		if command == c {
@@ -250,9 +244,6 @@ type tachoMotorStopActions tachoMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *tachoMotorStopActions) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*tachoMotor)(m).stopActions()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -854,9 +845,6 @@ type tachoMotorStopAction tachoMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
 func (m *tachoMotorStopAction) ReadAt(b []byte, offset int64) (int, error) {
-	if len((*tachoMotor)(m).stopActions()) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	return readAt(b, offset, m)
 }
 
@@ -867,9 +855,6 @@ func (m *tachoMotorStopAction) Truncate(_ int64) error { return nil }
 func (m *tachoMotorStopAction) WriteAt(b []byte, off int64) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m._stopActions) == 0 {
-		return len(b), syscall.ENOTSUP
-	}
 	stopAction := string(chomp(b))
 	for _, c := range m._stopActions {
 		if stopAction == c {
@@ -1184,12 +1169,6 @@ func TestTachoMotor(t *testing.T) {
 			}
 			commands, err := m.Commands()
 			want := c.tachoMotor.commands()
-			if len(want) == 0 {
-				if err == nil {
-					t.Error("expected error getting commands from non-commandable tachoMotor")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting commands: %v", err)
 			}
@@ -1702,12 +1681,6 @@ func TestTachoMotor(t *testing.T) {
 			}
 			stopActions, err := m.StopActions()
 			want := c.tachoMotor.stopActions()
-			if len(want) == 0 {
-				if err == nil {
-					t.Error("expected error getting stop actions from non-stop action tachoMotor")
-				}
-				continue
-			}
 			if err != nil {
 				t.Fatalf("unexpected error getting stop actions: %v", err)
 			}


### PR DESCRIPTION
See https://github.com/ev3go/ev3dev/issues/53#issuecomment-333283141

Updates #53.
Updates #54.
Updates #55.