### PR TITLE
ev3dev: cache invariant values

### DIFF
--- a/dc_motor.go
+++ b/dc_motor.go
@@ -41,7 +41,10 @@ func (m *DCMotor) Err() error {
 }
 
 // idInt and setID satisfy the idSetter interface.
-func (m *DCMotor) setID(id int) { *m = DCMotor{id: id} }
+func (m *DCMotor) setID(id int) error {
+	*m = DCMotor{id: id}
+	return nil
+}
 func (m *DCMotor) idInt() int {
 	if m == nil {
 		return -1
@@ -58,7 +61,12 @@ func DCMotorFor(port, driver string) (*DCMotor, error) {
 	if id == -1 {
 		return nil, err
 	}
-	return &DCMotor{id: id}, err
+	var m DCMotor
+	_err := m.setID(id)
+	if _err != nil {
+		err = _err
+	}
+	return &m, err
 }
 
 // Next returns a DCMotor for the next motor with the same device driver as

--- a/dc_motor.go
+++ b/dc_motor.go
@@ -17,6 +17,7 @@ type DCMotor struct {
 	id int
 
 	// Cached values:
+	driver                string
 	commands, stopActions []string
 
 	err error
@@ -52,6 +53,10 @@ func (m *DCMotor) setID(id int) error {
 		goto fail
 	}
 	t.stopActions, err = stringSliceFrom(attributeOf(&t, stopActions))
+	if err != nil {
+		goto fail
+	}
+	t.driver, err = DriverFor(&t)
 	if err != nil {
 		goto fail
 	}
@@ -98,6 +103,11 @@ func (m *DCMotor) Next() (*DCMotor, error) {
 		return nil, err
 	}
 	return &DCMotor{id: id}, err
+}
+
+// Driver returns the driver used by the DCMotor.
+func (m *DCMotor) Driver() string {
+	return m.driver
 }
 
 // Commands returns the available commands for the DCMotor.

--- a/dc_motor_test.go
+++ b/dc_motor_test.go
@@ -716,11 +716,8 @@ func TestDCMotor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			commands, err := m.Commands()
+			commands := m.Commands()
 			want := c.dcMotor.commands()
-			if err != nil {
-				t.Fatalf("unexpected error getting commands: %v", err)
-			}
 			if !reflect.DeepEqual(commands, want) {
 				t.Errorf("unexpected commands value: got:%q want:%q", commands, want)
 			}
@@ -934,10 +931,7 @@ func TestDCMotor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			stopActions, err := m.StopActions()
-			if err != nil {
-				t.Fatalf("unexpected error getting stop actions: %v", err)
-			}
+			stopActions := m.StopActions()
 			want := c.dcMotor.stopActions()
 			if !reflect.DeepEqual(stopActions, want) {
 				t.Errorf("unexpected stop actions value: got:%q want:%q", stopActions, want)

--- a/dc_motor_test.go
+++ b/dc_motor_test.go
@@ -638,6 +638,10 @@ func TestDCMotor(t *testing.T) {
 			if gotDriver != wantDriver {
 				t.Errorf("unexpected value for driver name: got:%q want:%q", gotDriver, wantDriver)
 			}
+			methodDriver := got.Driver()
+			if methodDriver != wantDriver {
+				t.Errorf("unexpected value for driver name: got:%q want:%q", methodDriver, wantDriver)
+			}
 		}
 	})
 

--- a/ev3dev.go
+++ b/ev3dev.go
@@ -6,11 +6,11 @@
 // See documentation at http://www.ev3dev.org/docs/drivers/.
 //
 // The API provided in the ev3dev package allows fluent chaining of action calls.
-// Methods for each of the device handle types are split into two classes: action
-// and result. Action method calls return the receiver and result method calls
+// Methods for each of the device handle types are split into three classes: action,
+// result and constant. Action method calls return the receiver and result method calls
 // return an error value generally with another result. Action methods result in
 // a change of state in the robot while result methods return the requested attribute
-// state of the robot.
+// state of the robot. Constant methods return values that are constant for the device.
 //
 // To allow fluent call chains, errors are sticky for action methods and are cleared
 // and returned by result methods. In a chain of calls the first error that is caused

--- a/ev3dev.go
+++ b/ev3dev.go
@@ -299,7 +299,7 @@ type idSetter interface {
 	// setID sets the device id to the given id
 	// and clears the error field to allow an
 	// already used Device to be reused.
-	setID(id int)
+	setID(id int) error
 }
 
 // FindAfter finds the first device after d matching the class of the
@@ -327,8 +327,7 @@ func FindAfter(d, dst Device, driver string) error {
 	if err != nil {
 		return err
 	}
-	dst.(idSetter).setID(id)
-	return nil
+	return dst.(idSetter).setID(id)
 }
 
 // IsConnected returns whether the Device is connected.

--- a/examples/demo/demo.go
+++ b/examples/demo/demo.go
@@ -35,10 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to set brake stop for medium motor on outA: %v", err)
 	}
-	maxMedium, err := outA.MaxSpeed()
-	if err != nil {
-		log.Fatalf("failed to get maximum speed for medium motor: %v", err)
-	}
+	maxMedium := outA.MaxSpeed()
 
 	// Get the handle for the left large motor on outB.
 	outB, err := ev3dev.TachoMotorFor("outB", "lego-ev3-l-motor")
@@ -49,10 +46,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to set brake stop for left large motor on outB: %v", err)
 	}
-	maxLarge, err := outB.MaxSpeed()
-	if err != nil {
-		log.Fatalf("failed to get maximum speed for large motor: %v", err)
-	}
+	maxLarge := outB.MaxSpeed()
 
 	// Get the handle for the right large motor on outC.
 	outC, err := ev3dev.TachoMotorFor("outC", "lego-ev3-l-motor")

--- a/examples/znap/znap.go
+++ b/examples/znap/znap.go
@@ -69,11 +69,7 @@ func znap() {
 	if err != nil {
 		log.Fatalf("failed to find motor for jaw in outB: %v", err)
 	}
-	max, err := jaw.MaxSpeed()
-	if err != nil {
-		log.Fatalf("failed to read maximum jaw speed: %v", err)
-	}
-	max /= 2
+	max := jaw.MaxSpeed() / 2
 	err = jaw.
 		SetRampUpSetpoint(200 * time.Millisecond).
 		SetRampDownSetpoint(200 * time.Millisecond).
@@ -223,11 +219,7 @@ func wander() {
 	if err != nil {
 		log.Fatalf("failed to set initialize right track: %v", err)
 	}
-	max, err := left.MaxSpeed() // Assume left and right have same maximum.
-	if err != nil {
-		log.Fatalf("failed to read maximum track speed: %v", err)
-	}
-	max /= 2
+	max := left.MaxSpeed() / 2 // Assume left and right have same maximum.
 
 	s := motorutil.Steering{Left: left, Right: right, Timeout: 5 * time.Second}
 	for {

--- a/lego_port.go
+++ b/lego_port.go
@@ -39,7 +39,10 @@ func (p *LegoPort) Err() error {
 }
 
 // idInt and setID satisfy the idSetter interface.
-func (p *LegoPort) setID(id int) { *p = LegoPort{id: id} }
+func (p *LegoPort) setID(id int) error {
+	*p = LegoPort{id: id}
+	return nil
+}
 func (p *LegoPort) idInt() int {
 	if p == nil {
 		return -1
@@ -56,7 +59,12 @@ func LegoPortFor(port, driver string) (*LegoPort, error) {
 	if id == -1 {
 		return nil, err
 	}
-	return &LegoPort{id: id}, err
+	var p LegoPort
+	_err := p.setID(id)
+	if _err != nil {
+		err = _err
+	}
+	return &p, err
 }
 
 // Next returns a LegoPort for the next port with the same device driver as

--- a/lego_port.go
+++ b/lego_port.go
@@ -24,7 +24,8 @@ type LegoPort struct {
 	id int
 
 	// Cached values:
-	modes []string
+	driver string
+	modes  []string
 
 	err error
 }
@@ -47,11 +48,18 @@ func (p *LegoPort) setID(id int) error {
 	var err error
 	t.modes, err = stringSliceFrom(attributeOf(&t, modes))
 	if err != nil {
-		*p = LegoPort{id: -1}
-		return err
+		goto fail
+	}
+	t.driver, err = DriverFor(&t)
+	if err != nil {
+		goto fail
 	}
 	*p = t
 	return nil
+
+fail:
+	*p = LegoPort{id: -1}
+	return err
 }
 func (p *LegoPort) idInt() int {
 	if p == nil {
@@ -89,6 +97,11 @@ func (p *LegoPort) Next() (*LegoPort, error) {
 		return nil, err
 	}
 	return &LegoPort{id: id}, err
+}
+
+// Driver returns the driver used by the LegoPort.
+func (p *LegoPort) Driver() string {
+	return p.driver
 }
 
 // Modes returns the available modes for the LegoPort.

--- a/lego_port.go
+++ b/lego_port.go
@@ -113,6 +113,17 @@ func (p *LegoPort) SetMode(m string) *LegoPort {
 	if p.err != nil {
 		return p
 	}
+	ok := false
+	for _, a := range p.modes {
+		if a == m {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		p.err = newInvalidValueError(p, mode, "", m, p.Modes())
+		return p
+	}
 	p.err = setAttributeOf(p, mode, m)
 	return p
 }

--- a/lego_port_test.go
+++ b/lego_port_test.go
@@ -351,6 +351,10 @@ func TestLegoPort(t *testing.T) {
 			if gotDriver != wantDriver {
 				t.Errorf("unexpected value for driver name: got:%q want:%q", gotDriver, wantDriver)
 			}
+			methodDriver := got.Driver()
+			if methodDriver != wantDriver {
+				t.Errorf("unexpected value for driver name: got:%q want:%q", methodDriver, wantDriver)
+			}
 		}
 	})
 

--- a/lego_port_test.go
+++ b/lego_port_test.go
@@ -428,10 +428,7 @@ func TestLegoPort(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		modes, err := p.Modes()
-		if err != nil {
-			t.Fatalf("unexpected error getting modes: %v", err)
-		}
+		modes := p.Modes()
 		want := conn[0].legoPort.modes()
 		if !reflect.DeepEqual(modes, want) {
 			t.Errorf("unexpected modes value: got:%q want:%q", modes, want)

--- a/linear_actuator.go
+++ b/linear_actuator.go
@@ -18,6 +18,7 @@ type LinearActuator struct {
 	id int
 
 	// Cached values:
+	driver                                   string
 	countPerMeter, fullTravelCount, maxSpeed int
 	commands, stopActions                    []string
 
@@ -69,6 +70,10 @@ func (m *LinearActuator) setID(id int) error {
 	if err != nil {
 		goto fail
 	}
+	t.driver, err = DriverFor(&t)
+	if err != nil {
+		goto fail
+	}
 	*m = t
 	return nil
 
@@ -112,6 +117,11 @@ func (m *LinearActuator) Next() (*LinearActuator, error) {
 		return nil, err
 	}
 	return &LinearActuator{id: id}, err
+}
+
+// Driver returns the driver used by the LinearActuator.
+func (m *LinearActuator) Driver() string {
+	return m.driver
 }
 
 // Commands returns the available commands for the LinearActuator.

--- a/linear_actuator.go
+++ b/linear_actuator.go
@@ -42,7 +42,10 @@ func (m *LinearActuator) Err() error {
 }
 
 // idInt and setID satisfy the idSetter interface.
-func (m *LinearActuator) setID(id int) { *m = LinearActuator{id: id} }
+func (m *LinearActuator) setID(id int) error {
+	*m = LinearActuator{id: id}
+	return nil
+}
 func (m *LinearActuator) idInt() int {
 	if m == nil {
 		return -1
@@ -59,7 +62,12 @@ func LinearActuatorFor(port, driver string) (*LinearActuator, error) {
 	if id == -1 {
 		return nil, err
 	}
-	return &LinearActuator{id: id}, err
+	var m LinearActuator
+	_err := m.setID(id)
+	if _err != nil {
+		err = _err
+	}
+	return &m, err
 }
 
 // Next returns a LinearActuator for the next motor with the same device driver as

--- a/linear_actuator_test.go
+++ b/linear_actuator_test.go
@@ -267,21 +267,21 @@ func (m *linearActuatorStopActions) String() string {
 	return strings.Join(m._stopActions, " ")
 }
 
-// linearActuatorCountsPerMeter is the counts_per_m attribute.
-type linearActuatorCountsPerMeter linearActuator
+// linearActuatorCountPerMeter is the counts_per_m attribute.
+type linearActuatorCountPerMeter linearActuator
 
 // ReadAt satisfies the io.ReaderAt interface.
-func (m *linearActuatorCountsPerMeter) ReadAt(b []byte, offset int64) (int, error) {
+func (m *linearActuatorCountPerMeter) ReadAt(b []byte, offset int64) (int, error) {
 	return readAt(b, offset, m)
 }
 
 // Size returns the length of the backing data and a nil error.
-func (m *linearActuatorCountsPerMeter) Size() (int64, error) {
+func (m *linearActuatorCountPerMeter) Size() (int64, error) {
 	return size(m), nil
 }
 
 // String returns a string representation of the attribute.
-func (m *linearActuatorCountsPerMeter) String() string {
+func (m *linearActuatorCountPerMeter) String() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return strconv.Itoa(m._countPerM)
@@ -981,7 +981,7 @@ func connectedLinearActuators(c ...linearActuatorConn) []sisyphus.Node {
 			ro(DriverNameName, 0444, (*linearActuatorDriver)(m.linearActuator)),
 			ro(CommandsName, 0444, (*linearActuatorCommands)(m.linearActuator)),
 			wo(CommandName, 0222, (*linearActuatorCommand)(m.linearActuator)),
-			ro(CountPerMeterName, 0444, (*linearActuatorCountsPerMeter)(m.linearActuator)),
+			ro(CountPerMeterName, 0444, (*linearActuatorCountPerMeter)(m.linearActuator)),
 			ro(FullTravelCountName, 0444, (*linearActuatorFullTravelCount)(m.linearActuator)),
 			rw(PolarityName, 0666, (*linearActuatorPolarity)(m.linearActuator)),
 			ro(DutyCycleName, 0444, (*linearActuatorDutyCycle)(m.linearActuator)),

--- a/linear_actuator_test.go
+++ b/linear_actuator_test.go
@@ -1122,6 +1122,10 @@ func TestLinearActuator(t *testing.T) {
 			if gotDriver != wantDriver {
 				t.Errorf("unexpected value for driver name: got:%q want:%q", gotDriver, wantDriver)
 			}
+			methodDriver := got.Driver()
+			if methodDriver != wantDriver {
+				t.Errorf("unexpected value for driver name: got:%q want:%q", methodDriver, wantDriver)
+			}
 		}
 	})
 

--- a/motorutil/steer.go
+++ b/motorutil/steer.go
@@ -72,14 +72,8 @@ func (s *Steering) StopActions() ([]string, error) {
 		return nil, err
 	}
 
-	lActions, err := s.Left.StopActions()
-	if err != nil {
-		return nil, err
-	}
-	rActions, err := s.Right.StopActions()
-	if err != nil {
-		return nil, err
-	}
+	lActions := s.Left.StopActions()
+	rActions := s.Right.StopActions()
 	sort.Strings(lActions)
 	sort.Strings(rActions)
 	if !equal(lActions, rActions) {

--- a/sensor.go
+++ b/sensor.go
@@ -43,7 +43,10 @@ func (s *Sensor) Err() error {
 }
 
 // idInt and setID satisfy the idSetter interface.
-func (s *Sensor) setID(id int) { *s = Sensor{id: id} }
+func (s *Sensor) setID(id int) error {
+	*s = Sensor{id: id}
+	return nil
+}
 func (s *Sensor) idInt() int {
 	if s == nil {
 		return -1
@@ -60,7 +63,12 @@ func SensorFor(port, driver string) (*Sensor, error) {
 	if id == -1 {
 		return nil, err
 	}
-	return &Sensor{id: id}, err
+	var s Sensor
+	_err := s.setID(id)
+	if _err != nil {
+		err = _err
+	}
+	return &s, err
 }
 
 // Next returns a Sensor for the next sensor with the same device driver as

--- a/sensor.go
+++ b/sensor.go
@@ -215,6 +215,17 @@ func (s *Sensor) SetMode(m string) *Sensor {
 	if s.err != nil {
 		return s
 	}
+	ok := false
+	for _, a := range s.modes {
+		if a == m {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		s.err = newInvalidValueError(s, mode, "", m, s.Modes())
+		return s
+	}
 	s.err = setAttributeOf(s, mode, m)
 	return s
 }

--- a/sensor.go
+++ b/sensor.go
@@ -19,8 +19,8 @@ type Sensor struct {
 	id int
 
 	// Cached values:
-	firmwareVersion string
-	commands, modes []string
+	driver, firmwareVersion string
+	commands, modes         []string
 
 	err error
 }
@@ -59,6 +59,10 @@ func (s *Sensor) setID(id int) error {
 		goto fail
 	}
 	t.modes, err = stringSliceFrom(attributeOf(&t, modes))
+	if err != nil {
+		goto fail
+	}
+	t.driver, err = DriverFor(&t)
 	if err != nil {
 		goto fail
 	}
@@ -136,6 +140,11 @@ func (s *Sensor) BinData() ([]byte, error) {
 //  float: IEEE 754 32-bit floating point (float)
 func (s *Sensor) BinDataFormat() (string, error) {
 	return stringFrom(attributeOf(s, binDataFormat))
+}
+
+// Driver returns the driver used by the Sensor.
+func (s *Sensor) Driver() string {
+	return s.driver
 }
 
 // Commands returns the available commands for the Sensor.

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -682,6 +682,10 @@ func TestSensor(t *testing.T) {
 			if gotDriver != wantDriver {
 				t.Errorf("unexpected value for driver name: got:%q want:%q", gotDriver, wantDriver)
 			}
+			methodDriver := got.Driver()
+			if methodDriver != wantDriver {
+				t.Errorf("unexpected value for driver name: got:%q want:%q", methodDriver, wantDriver)
+			}
 		}
 	})
 

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -767,10 +767,7 @@ func TestSensor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		modes, err := s.Modes()
-		if err != nil {
-			t.Fatalf("unexpected error getting modes: %v", err)
-		}
+		modes := s.Modes()
 		want := conn[0].sensor.modes()
 		if !reflect.DeepEqual(modes, want) {
 			t.Errorf("unexpected modes value: got:%q want:%q", modes, want)
@@ -813,11 +810,8 @@ func TestSensor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			commands, err := s.Commands()
+			commands := s.Commands()
 			want := c.sensor.commands()
-			if err != nil {
-				t.Fatalf("unexpected error getting commands: %v", err)
-			}
 			if !reflect.DeepEqual(commands, want) {
 				t.Errorf("unexpected commands value: got:%q want:%q", commands, want)
 			}
@@ -944,11 +938,7 @@ func TestSensor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		modes, err := s.Modes()
-		if err != nil {
-			t.Fatalf("unexpected error getting modes: %v", err)
-		}
-		for _, mode := range modes {
+		for _, mode := range s.Modes() {
 			err := s.SetMode(mode).Err()
 			if err != nil {
 				t.Errorf("unexpected error for mode %q: %v", mode, err)
@@ -975,11 +965,7 @@ func TestSensor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		modes, err := s.Modes()
-		if err != nil {
-			t.Fatalf("unexpected error getting modes: %v", err)
-		}
-		for _, mode := range modes {
+		for _, mode := range s.Modes() {
 			err := s.SetMode(mode).Err()
 			if err != nil {
 				t.Errorf("unexpected error for mode %q: %v", mode, err)

--- a/servo_motor.go
+++ b/servo_motor.go
@@ -41,7 +41,10 @@ func (m *ServoMotor) Err() error {
 }
 
 // idInt and setID satisfy the idSetter interface.
-func (m *ServoMotor) setID(id int) { *m = ServoMotor{id: id} }
+func (m *ServoMotor) setID(id int) error {
+	*m = ServoMotor{id: id}
+	return nil
+}
 func (m *ServoMotor) idInt() int {
 	if m == nil {
 		return -1
@@ -58,7 +61,12 @@ func ServoMotorFor(port, driver string) (*ServoMotor, error) {
 	if id == -1 {
 		return nil, err
 	}
-	return &ServoMotor{id: id}, err
+	var m ServoMotor
+	_err := m.setID(id)
+	if _err != nil {
+		err = _err
+	}
+	return &m, err
 }
 
 // Next returns a ServoMotor for the next motor with the same device driver as

--- a/servo_motor.go
+++ b/servo_motor.go
@@ -16,6 +16,9 @@ var _ idSetter = (*ServoMotor)(nil)
 type ServoMotor struct {
 	id int
 
+	// Cached value:
+	driver string
+
 	err error
 }
 
@@ -42,7 +45,14 @@ func (m *ServoMotor) Err() error {
 
 // idInt and setID satisfy the idSetter interface.
 func (m *ServoMotor) setID(id int) error {
-	*m = ServoMotor{id: id}
+	t := ServoMotor{id: id}
+	var err error
+	t.driver, err = DriverFor(&t)
+	if err != nil {
+		*m = ServoMotor{id: -1}
+		return err
+	}
+	*m = t
 	return nil
 }
 func (m *ServoMotor) idInt() int {
@@ -81,6 +91,11 @@ func (m *ServoMotor) Next() (*ServoMotor, error) {
 		return nil, err
 	}
 	return &ServoMotor{id: id}, err
+}
+
+// Driver returns the driver used by the ServoMotor.
+func (p *ServoMotor) Driver() string {
+	return p.driver
 }
 
 // Commands returns the available commands for the ServoMotor.

--- a/servo_motor_test.go
+++ b/servo_motor_test.go
@@ -547,6 +547,10 @@ func TestServoMotor(t *testing.T) {
 			if gotDriver != wantDriver {
 				t.Errorf("unexpected value for driver name: got:%q want:%q", gotDriver, wantDriver)
 			}
+			methodDriver := got.Driver()
+			if methodDriver != wantDriver {
+				t.Errorf("unexpected value for driver name: got:%q want:%q", methodDriver, wantDriver)
+			}
 		}
 	})
 

--- a/tacho_motor.go
+++ b/tacho_motor.go
@@ -42,7 +42,10 @@ func (m *TachoMotor) Err() error {
 }
 
 // idInt and setID satisfy the idSetter interface.
-func (m *TachoMotor) setID(id int) { *m = TachoMotor{id: id} }
+func (m *TachoMotor) setID(id int) error {
+	*m = TachoMotor{id: id}
+	return nil
+}
 func (m *TachoMotor) idInt() int {
 	if m == nil {
 		return -1
@@ -59,7 +62,12 @@ func TachoMotorFor(port, driver string) (*TachoMotor, error) {
 	if id == -1 {
 		return nil, err
 	}
-	return &TachoMotor{id: id}, err
+	var m TachoMotor
+	_err := m.setID(id)
+	if _err != nil {
+		err = _err
+	}
+	return &m, err
 }
 
 // Next returns a TachoMotor for the next motor with the same device driver as

--- a/tacho_motor.go
+++ b/tacho_motor.go
@@ -18,6 +18,7 @@ type TachoMotor struct {
 	id int
 
 	// Cached values:
+	driver                string
 	countPerRot, maxSpeed int
 	commands, stopActions []string
 
@@ -65,6 +66,10 @@ func (m *TachoMotor) setID(id int) error {
 	if err != nil {
 		goto fail
 	}
+	t.driver, err = DriverFor(&t)
+	if err != nil {
+		goto fail
+	}
 	*m = t
 	return nil
 
@@ -108,6 +113,11 @@ func (m *TachoMotor) Next() (*TachoMotor, error) {
 		return nil, err
 	}
 	return &TachoMotor{id: id}, err
+}
+
+// Driver returns the driver used by the TachoMotor.
+func (m *TachoMotor) Driver() string {
+	return m.driver
 }
 
 // Commands returns the available commands for the TachoMotor.

--- a/tacho_motor_test.go
+++ b/tacho_motor_test.go
@@ -1016,6 +1016,9 @@ func TestTachoMotor(t *testing.T) {
 					"reset",
 				},
 
+				_maxSpeed:    1200,
+				_countPerRot: 360,
+
 				_lastStopAction: "coast",
 				_stopActions: []string{
 					"coast",
@@ -1167,11 +1170,8 @@ func TestTachoMotor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			commands, err := m.Commands()
+			commands := m.Commands()
 			want := c.tachoMotor.commands()
-			if err != nil {
-				t.Fatalf("unexpected error getting commands: %v", err)
-			}
 			if !reflect.DeepEqual(commands, want) {
 				t.Errorf("unexpected commands value: got:%q want:%q", commands, want)
 			}
@@ -1208,16 +1208,10 @@ func TestTachoMotor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			for _, n := range []int{0, 64, 128, 192, 255} {
-				c.tachoMotor.setCountsPerRot(n)
-				got, err := m.CountPerRot()
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				want := c.tachoMotor.countsPerRot()
-				if got != want {
-					t.Errorf("unexpected count per rot value: got:%d want:%d", got, want)
-				}
+			got := m.CountPerRot()
+			want := c.tachoMotor.countsPerRot()
+			if got != want {
+				t.Errorf("unexpected count per rot value: got:%d want:%d", got, want)
 			}
 		}
 	})
@@ -1455,16 +1449,10 @@ func TestTachoMotor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			for _, s := range []int{0, 64, 128, 192, 255} {
-				c.tachoMotor.setMaxSpeed(s)
-				got, err := m.MaxSpeed()
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				want := c.tachoMotor.maxSpeed()
-				if got != want {
-					t.Errorf("unexpected max speed value: got:%d want:%d", got, want)
-				}
+			got := m.MaxSpeed()
+			want := c.tachoMotor.maxSpeed()
+			if got != want {
+				t.Errorf("unexpected max speed value: got:%d want:%d", got, want)
 			}
 		}
 	})
@@ -1679,11 +1667,8 @@ func TestTachoMotor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			stopActions, err := m.StopActions()
+			stopActions := m.StopActions()
 			want := c.tachoMotor.stopActions()
-			if err != nil {
-				t.Fatalf("unexpected error getting stop actions: %v", err)
-			}
 			if !reflect.DeepEqual(stopActions, want) {
 				t.Errorf("unexpected stop actions value: got:%q want:%q", stopActions, want)
 			}

--- a/tacho_motor_test.go
+++ b/tacho_motor_test.go
@@ -82,13 +82,13 @@ func (m *tachoMotor) lastCommand() string {
 	return m._lastCommand
 }
 
-func (m *tachoMotor) countsPerRot() int {
+func (m *tachoMotor) countPerRot() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m._countPerRot
 }
 
-func (m *tachoMotor) setCountsPerRot(n int) {
+func (m *tachoMotor) setCountPerRot(n int) {
 	m.mu.Lock()
 	m._countPerRot = n
 	m.mu.Unlock()
@@ -260,21 +260,21 @@ func (m *tachoMotorStopActions) String() string {
 	return strings.Join(m._stopActions, " ")
 }
 
-// tachoMotorCountsPerRot is the counts_per_rot attribute.
-type tachoMotorCountsPerRot tachoMotor
+// tachoMotorCountPerRot is the counts_per_rot attribute.
+type tachoMotorCountPerRot tachoMotor
 
 // ReadAt satisfies the io.ReaderAt interface.
-func (m *tachoMotorCountsPerRot) ReadAt(b []byte, offset int64) (int, error) {
+func (m *tachoMotorCountPerRot) ReadAt(b []byte, offset int64) (int, error) {
 	return readAt(b, offset, m)
 }
 
 // Size returns the length of the backing data and a nil error.
-func (m *tachoMotorCountsPerRot) Size() (int64, error) {
+func (m *tachoMotorCountPerRot) Size() (int64, error) {
 	return size(m), nil
 }
 
 // String returns a string representation of the attribute.
-func (m *tachoMotorCountsPerRot) String() string {
+func (m *tachoMotorCountPerRot) String() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return strconv.Itoa(m._countPerRot)
@@ -954,7 +954,7 @@ func connectedTachoMotors(c ...tachoMotorConn) []sisyphus.Node {
 			ro(DriverNameName, 0444, (*tachoMotorDriver)(m.tachoMotor)),
 			ro(CommandsName, 0444, (*tachoMotorCommands)(m.tachoMotor)),
 			wo(CommandName, 0222, (*tachoMotorCommand)(m.tachoMotor)),
-			ro(CountPerRotName, 0444, (*tachoMotorCountsPerRot)(m.tachoMotor)),
+			ro(CountPerRotName, 0444, (*tachoMotorCountPerRot)(m.tachoMotor)),
 			rw(PolarityName, 0666, (*tachoMotorPolarity)(m.tachoMotor)),
 			ro(DutyCycleName, 0444, (*tachoMotorDutyCycle)(m.tachoMotor)),
 			rw(DutyCycleSetpointName, 0666, (*tachoMotorDutyCycleSet)(m.tachoMotor)),
@@ -1209,7 +1209,7 @@ func TestTachoMotor(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			got := m.CountPerRot()
-			want := c.tachoMotor.countsPerRot()
+			want := c.tachoMotor.countPerRot()
 			if got != want {
 				t.Errorf("unexpected count per rot value: got:%d want:%d", got, want)
 			}

--- a/tacho_motor_test.go
+++ b/tacho_motor_test.go
@@ -1092,6 +1092,10 @@ func TestTachoMotor(t *testing.T) {
 			if gotDriver != wantDriver {
 				t.Errorf("unexpected value for driver name: got:%q want:%q", gotDriver, wantDriver)
 			}
+			methodDriver := got.Driver()
+			if methodDriver != wantDriver {
+				t.Errorf("unexpected value for driver name: got:%q want:%q", methodDriver, wantDriver)
+			}
 		}
 	})
 

--- a/wait_test.go
+++ b/wait_test.go
@@ -144,6 +144,58 @@ func (m *waitMotorDriver) Size() (int64, error) {
 	return size(m.driver), nil
 }
 
+// waitMotorCommands is the commands attribute.
+type waitMotorCommands waitMotor
+
+// ReadAt satisfies the io.ReaderAt interface.
+func (m *waitMotorCommands) ReadAt(b []byte, offset int64) (int, error) {
+	return readAt(b, offset, "none")
+}
+
+// Size returns the length of the backing data and a nil error.
+func (m *waitMotorCommands) Size() (int64, error) {
+	return size("none"), nil
+}
+
+// waitMotorStopActions is the stop_actions attribute.
+type waitMotorStopActions waitMotor
+
+// ReadAt satisfies the io.ReaderAt interface.
+func (m *waitMotorStopActions) ReadAt(b []byte, offset int64) (int, error) {
+	return readAt(b, offset, "none")
+}
+
+// Size returns the length of the backing data and a nil error.
+func (m *waitMotorStopActions) Size() (int64, error) {
+	return size("none"), nil
+}
+
+// waitMotorMaxSpeed is the max_speed attribute.
+type waitMotorMaxSpeed waitMotor
+
+// ReadAt satisfies the io.ReaderAt interface.
+func (m *waitMotorMaxSpeed) ReadAt(b []byte, offset int64) (int, error) {
+	return readAt(b, offset, "1200")
+}
+
+// Size returns the length of the backing data and a nil error.
+func (m *waitMotorMaxSpeed) Size() (int64, error) {
+	return size("1200"), nil
+}
+
+// waitMotorCountsPerRot is the count_per_rot attribute.
+type waitMotorCountPerRot waitMotor
+
+// ReadAt satisfies the io.ReaderAt interface.
+func (m *waitMotorCountPerRot) ReadAt(b []byte, offset int64) (int, error) {
+	return readAt(b, offset, "360")
+}
+
+// Size returns the length of the backing data and a nil error.
+func (m *waitMotorCountPerRot) Size() (int64, error) {
+	return size("360"), nil
+}
+
 // waitMotorState is the state attribute.
 type waitMotorState waitMotor
 
@@ -179,6 +231,10 @@ func connectedWaitMotors(c ...waitMotorConn) []sisyphus.Node {
 		n[i] = d(fmt.Sprintf("motor%d", m.id), 0775).With(
 			ro(AddressName, 0444, (*waitMotorAddress)(m.waitMotor)),
 			ro(DriverNameName, 0444, (*waitMotorDriver)(m.waitMotor)),
+			ro(CommandsName, 0444, (*waitMotorCommands)(m.waitMotor)),
+			ro(CountPerRotName, 0444, (*waitMotorCountPerRot)(m.waitMotor)),
+			ro(MaxSpeedName, 0444, (*waitMotorMaxSpeed)(m.waitMotor)),
+			ro(StopActionsName, 0444, (*waitMotorStopActions)(m.waitMotor)),
 			ro(StateName, 0444, (*waitMotorState)(m.waitMotor)),
 		)
 	}


### PR DESCRIPTION
@dlech Please take a look.

This does not cache `address`; I want `address` to be dynamic so that it returns an invalid value and error if the device is removed.

Breaking change.

Updates #53.
Updates #54.
Updates #55.