### PR TITLE
ev3dev: handle zero-length commands case

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -60,7 +61,13 @@ func (s *Sensor) setID(id int) error {
 	}
 	t.commands, err = stringSliceFrom(attributeOf(&t, commands))
 	if err != nil {
-		goto fail
+		cerr := cause(err)
+		if _err, ok := cerr.(*os.PathError); ok {
+			cerr = _err.Err
+		}
+		if cerr != syscall.ENOTSUP {
+			goto fail
+		}
 	}
 	t.modes, err = stringSliceFrom(attributeOf(&t, modes))
 	if err != nil {


### PR DESCRIPTION
@dlech Please take a look.

~~I have sprinkled pixy dust on the motors as well, just in case, and I'm now feeling uneasy about `stop_actions`. Can you confirm that `stop_actions` will not behave the way sensors currently do with `commands`. I can see `modes` won't since there must be at lease one mode for devices with the `modes` attribute according to the docs.~~

Fixes #69.
Updates #52 (if https://github.com/ev3dev/ev3dev/issues/986 is fixed in stretch, I want to remove this work around in the forthcoming stretch branch).
