### PR TITLE
fixed low level API path for Buttons

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,4 +11,5 @@
 Christopher Hlubek <christopher.hlubek@networkteam.com>
 Dan Kortschak <dan.kortschak@adelaide.edu.au>
 David Lechner <david@lechnology.com>
+Nick Demidov <nikolay.demidov@gmail.com>
 Renée French

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,3 +18,4 @@
 Christopher Hlubek <christopher.hlubek@networkteam.com>
 Dan Kortschak <dan.kortschak@adelaide.edu.au>
 David Lechner <david@lechnology.com>
+Nick Demidov <nikolay.demidov@gmail.com>

--- a/ev3dev.go
+++ b/ev3dev.go
@@ -61,7 +61,7 @@ const (
 	LEDPath = "/sys/class/leds"
 
 	// ButtonPath is the path to the ev3 button events.
-	ButtonPath = "/dev/input/by-path/platform-gpio-keys.0-event"
+	ButtonPath = "/dev/input/by-path/platform-gpio_keys-event"
 
 	// LegoPortPath is the path to the ev3 lego-port file system.
 	LegoPortPath = "/sys/class/lego-port"


### PR DESCRIPTION
System path to the Buttons has been changed. I didn't find when but examples "poll" and "waitkeys" return error with ev3dev-stretch and ev3dev-jessie.
I've tested this fix in "poll" example with my lego brick and ev3dev-stretch.